### PR TITLE
handle the compare of DOCUMENT_FRAGMENT_NODE

### DIFF
--- a/lib/compare.js
+++ b/lib/compare.js
@@ -113,6 +113,8 @@
                // fallthrough
             case type.CDATA_SECTION_NODE:
                // fallthrough
+            case type.DOCUMENT_FRAGMENT_NODE:
+               // fallthrough 
             case type.COMMENT_NODE:
                if (left.nodeType == type.COMMENT_NODE && !this._options.compareComments)
                   return true;


### PR DESCRIPTION
Need to fallthrough when the left nodeType is DOCUMENT_FRAGMENT_NODE.