### PR TITLE
Collapse spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ Comparison function can take a third argument with options like this:
 ```javascript
 var options = {
     stripSpaces: true,
-    compareComments: true
+    compareComments: true,
+    collapseSpaces: true
 };
 
 result = compare(expected, actual, options);
@@ -106,9 +107,12 @@ By default, all comments are ignored. Set `compareComments` options to `true` to
 
 #### Whitespace comparison
 By default, all text nodes (text, CDATA, comments if enabled as mentioned above) compared with respect 
-to leading and trailing whitespaces.
+to leading, trailing, and internal whitespaces.
 Set `stripSpaces` option to `true` to automatically strip spaces in text and comment nodes. This option
 doesn't change the way CDATA sections is compared, they are always compared with respect to whitespaces.
+Set `collapseSpaces` option to `true` to automatically collapse all spaces in text and comment nodes.
+This option doesn't change the way CDATA sections is compared, they are always compared with respect to
+whitespaces.
 
 ### Cli utility
 

--- a/bin/domcompare
+++ b/bin/domcompare
@@ -36,6 +36,13 @@ argparser.addArgument([ '-s', '--stripspaces' ], {
     help: "Strip spaces when comparing strings (exclude CDATA nodes)"
 });
 
+argparser.addArgument([ '-s', '--collapsespaces' ], {
+    defaultValue: false,
+    dest: 'collapseSpaces',
+    action: 'storeTrue',
+    help: "Collapse spaces when comparing strings (exclude CDATA nodes)"
+});
+
 argparser.addArgument([ '-c', '--comments' ], {
     defaultValue: false,
     dest: 'compareComments',

--- a/lib/collapse_spaces.js
+++ b/lib/collapse_spaces.js
@@ -1,0 +1,9 @@
+(function(){
+
+  "use strict";
+
+  module.exports = function collapseSpaces(str) {
+    return str.replace(/\s\s+/g, ' ');
+  };
+
+})();

--- a/lib/collapse_spaces.js
+++ b/lib/collapse_spaces.js
@@ -3,7 +3,8 @@
   "use strict";
 
   module.exports = function collapseSpaces(str) {
-    return str.replace(/\s\s+/g, ' ');
+    // Replace all whitespace with the space character and then collapse all white space to one space character
+    return str.replace(/\s/g, ' ').replace(/\s\s+/g, ' ');
   };
 
 })();

--- a/lib/collector.js
+++ b/lib/collector.js
@@ -4,6 +4,7 @@
 
    var type = require('./node_types');
    var revxpath = require('./revxpath.js');
+   var collapseSpaces = require('./collapse_spaces');
 
    var typeMap = {},
        comparatorTypeMap = {};
@@ -29,7 +30,16 @@
       if(node.nodeType == type.TEXT_NODE ||
          node.nodeType == type.CDATA_SECTION_NODE ||
          node.nodeType == type.COMMENT_NODE) {
-         return "'" + (this._options.stripSpaces ? node.nodeValue.trim() : node.nodeValue) + "'";
+         var nodeValue = node.nodeValue;
+
+         if(this._options.stripSpaces) {
+            nodeValue = nodeValue.trim();
+         }
+         if(this._options.collapseSpaces) {
+            nodeValue = collapseSpaces(nodeValue);
+         }
+
+         return "'" + nodeValue + "'";
       }
       else
          return "'" + node.nodeName + "'";
@@ -92,6 +102,10 @@
                   if(this._options.stripSpaces && expected.nodeType != type.CDATA_SECTION_NODE) {
                      vExpected = vExpected.trim();
                      vActual = vActual.trim();
+                  }
+                  if(this._options.collapseSpaces && expected.nodeType != type.CDATA_SECTION_NODE) {
+                     vExpected = collapseSpaces(vExpected);
+                     vActual = collapseSpaces(vActual);
                   }
                   if(vExpected == vActual)
                      throw new Error("Nodes are considered equal but shouldn't");

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -4,6 +4,7 @@
 
    var type = require('./node_types');
    var Collector = require('./collector');
+   var collapseSpaces = require('./collapse_spaces');
 
    function Comparator(options, collector) {
       this._options = options || {};
@@ -71,6 +72,10 @@
             if(this._options.stripSpaces && aExpected[i].nodeType != type.CDATA_SECTION_NODE) {
                vExpected = vExpected.trim();
                vActual = vActual.trim();
+            }
+            if(this._options.collapseSpaces && aExpected[i].nodeType != type.CDATA_SECTION_NODE) {
+               vExpected = collapseSpaces(vExpected);
+               vActual = collapseSpaces(vActual);
             }
             if(vExpected !== vActual) {
                if(!this._collector.collectFailure(aExpected[i], aActual[i]))

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -133,6 +133,10 @@
                   vLeft = vLeft.trim();
                   vRight = vRight.trim();
                }
+               if (this._options.collapseSpaces && left.nodeType !== type.CDATA_SECTION_NODE) {
+                  vLeft = collapseSpaces(vLeft);
+                  vRight = collapseSpaces(vRight);
+               }
                r = vLeft === vRight;
                return !r ? this._collector.collectFailure(left, right) : r;
             default:


### PR DESCRIPTION

Adds a collapseSpaces option which changes how text and comment nodes are compared for equality by collapsing all the white space in them first.