### PR TITLE
Normalize newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ Comparison function can take a third argument with options like this:
 var options = {
     stripSpaces: true,
     compareComments: true,
-    collapseSpaces: true
+    collapseSpaces: true,
+    normalizeNewlines: true
 };
 
 result = compare(expected, actual, options);
@@ -113,6 +114,8 @@ doesn't change the way CDATA sections is compared, they are always compared with
 Set `collapseSpaces` option to `true` to automatically collapse all spaces in text and comment nodes.
 This option doesn't change the way CDATA sections is compared, they are always compared with respect to
 whitespaces.
+Set `normalizeNewlines` option to `true` to automatically normalize new line characters in text, 
+comment, and CDATA nodes.
 
 ### Cli utility
 

--- a/bin/domcompare
+++ b/bin/domcompare
@@ -43,6 +43,13 @@ argparser.addArgument([ '-s', '--collapsespaces' ], {
     help: "Collapse spaces when comparing strings (exclude CDATA nodes)"
 });
 
+argparser.addArgument([ '-s', '--normalizenewlines' ], {
+    defaultValue: false,
+    dest: 'normalizeNewlines',
+    action: 'storeTrue',
+    help: "Normalize newlines when comparing strings (include CDATA nodes)"
+});
+
 argparser.addArgument([ '-c', '--comments' ], {
     defaultValue: false,
     dest: 'compareComments',

--- a/lib/collector.js
+++ b/lib/collector.js
@@ -5,6 +5,7 @@
    var type = require('./node_types');
    var revxpath = require('./revxpath.js');
    var collapseSpaces = require('./collapse_spaces');
+   var normalizeNewlines = require('./normalize_newlines');
 
    var typeMap = {},
        comparatorTypeMap = {};
@@ -37,6 +38,9 @@
          }
          if(this._options.collapseSpaces) {
             nodeValue = collapseSpaces(nodeValue);
+         }
+         if(this._options.normalizeNewlines) {
+            nodeValue = normalizeNewlines(nodeValue);
          }
 
          return "'" + nodeValue + "'";
@@ -106,6 +110,10 @@
                   if(this._options.collapseSpaces && expected.nodeType != type.CDATA_SECTION_NODE) {
                      vExpected = collapseSpaces(vExpected);
                      vActual = collapseSpaces(vActual);
+                  }
+                  if(this._options.normalizeNewlines) {
+                     vExpected = normalizeNewlines(vExpected);
+                     vActual = normalizeNewlines(vActual);
                   }
                   if(vExpected == vActual)
                      throw new Error("Nodes are considered equal but shouldn't");

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -5,6 +5,7 @@
    var type = require('./node_types');
    var Collector = require('./collector');
    var collapseSpaces = require('./collapse_spaces');
+   var normalizeNewlines = require('./normalize_newlines');
 
    function Comparator(options, collector) {
       this._options = options || {};
@@ -77,6 +78,10 @@
                vExpected = collapseSpaces(vExpected);
                vActual = collapseSpaces(vActual);
             }
+            if(this._options.normalizeNewlines) {
+               vExpected = normalizeNewlines(vExpected);
+               vActual = normalizeNewlines(vActual);
+            }
             if(vExpected !== vActual) {
                if(!this._collector.collectFailure(aExpected[i], aActual[i]))
                   return false;
@@ -136,6 +141,10 @@
                if (this._options.collapseSpaces && left.nodeType !== type.CDATA_SECTION_NODE) {
                   vLeft = collapseSpaces(vLeft);
                   vRight = collapseSpaces(vRight);
+               }
+               if (this._options.normalizeNewlines) {
+                  vLeft = normalizeNewlines(vLeft);
+                  vRight = normalizeNewlines(vRight);
                }
                r = vLeft === vRight;
                return !r ? this._collector.collectFailure(left, right) : r;

--- a/lib/normalize_newlines.js
+++ b/lib/normalize_newlines.js
@@ -3,7 +3,8 @@
   "use strict";
 
   module.exports = function normalizeNewlines(str) {
-    return str.replace(/\r\n/g, '\n');
+    // First replace all CR+LF newlines then replace CR newlines
+    return str.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
   };
 
 })();

--- a/lib/normalize_newlines.js
+++ b/lib/normalize_newlines.js
@@ -1,0 +1,9 @@
+(function(){
+
+  "use strict";
+
+  module.exports = function normalizeNewlines(str) {
+    return str.replace(/\r\n/g, '\n');
+  };
+
+})();

--- a/test/test-compare.js
+++ b/test/test-compare.js
@@ -123,6 +123,12 @@ describe('Compare', function () {
                doc2 = parser.parseFromString("<doc><node a=' 1 \r\n\t 2 ' /></doc>");
                assert.equal(true, compare(doc1, doc2, { collapseSpaces: true }).getResult());
             });
+
+            it("but newlines can be normalized", function(){
+               doc1 = parser.parseFromString("<doc><node a=' 1 \n 2 ' /></doc>");
+               doc2 = parser.parseFromString("<doc><node a=' 1 \r\n 2 ' /></doc>");
+               assert.equal(true, compare(doc1, doc2, { normalizeNewlines: true }).getResult());
+            });
          });
 
       });
@@ -250,6 +256,27 @@ describe('Compare', function () {
                }).getResult());
             });
          });
+
+         describe("Newline normalizing", function () {
+            it("normally all whitespaces at the beginning/end are preserved", function () {
+               var doc1 = parser.parseFromString("<doc><!-- A \r\n \n B --></doc>");
+               var doc2 = parser.parseFromString("<doc><!-- A \r\n \n B --></doc>");
+               assert.equal(true, compare(doc1, doc2, { compareComments: true }).getResult());
+
+               doc1 = parser.parseFromString("<doc><!-- A \r\n \n B --></doc>");
+               doc2 = parser.parseFromString("<doc><!-- A \n \r\n B --></doc>");
+               assert.equal(false, compare(doc1, doc2, { compareComments: true }).getResult());
+            });
+
+            it("`normalizeNewlines` option normalizes them", function () {
+               var doc1 = parser.parseFromString("<doc><!-- \r A \r\n \n\r B \n --></doc>");
+               var doc2 = parser.parseFromString("<doc><!-- \r\n A \n \r\n\r B \r --></doc>");
+               assert.equal(true, compare(doc1, doc2, {
+                  compareComments: true,
+                  normalizeNewlines: true
+               }).getResult());
+            });
+         });
       });
 
       describe("Text", function () {
@@ -302,6 +329,12 @@ describe('Compare', function () {
             doc2 = parser.parseFromString("<doc><node> A \t\n\r B \t\n\r </node></doc>");
             assert.equal(true, compare(doc1, doc2, { collapseSpaces: true }).getResult());
          });
+
+         it("set `normalizeNewlines` option to normalize newlines", function () {
+            var doc1 = parser.parseFromString("<doc><node> \r\n A \r B \n </node></doc>");
+            var doc2 = parser.parseFromString("<doc><node> \n A \r\n B \r </node></doc>");
+            assert.equal(true, compare(doc1, doc2, { normalizeNewlines: true }).getResult());
+         });
       });
 
       describe("CDATA", function () {
@@ -337,6 +370,12 @@ describe('Compare', function () {
             doc1 = parser.parseFromString("<doc><![CDATA[ \n\r\t data  data \n\r\t ]]></doc>");
             doc2 = parser.parseFromString("<doc><![CDATA[ data \t\n\r data \t\n\r ]]></doc>");
             assert.equal(false, compare(doc1, doc2, { collapseSpaces: true }).getResult());
+         });
+
+         it("set `normalizeNewlines` option to normalize newlines", function () {
+            var doc1 = parser.parseFromString("<doc><![CDATA[ \r\n data \r data \n ]]></doc>");
+            var doc2 = parser.parseFromString("<doc><![CDATA[ \n data \r\n data \r ]]></doc>");
+            assert.equal(true, compare(doc1, doc2, { normalizeNewlines: true }).getResult());
          });
       });
    });

--- a/test/test-normalize_newlines.js
+++ b/test/test-normalize_newlines.js
@@ -1,0 +1,40 @@
+var assert = require('assert');
+var normalizeNewlines = require('../lib/normalize_newlines');
+
+describe('normalize_newlines', function () {
+  it('should transform CR+LF to LF', function() {
+    var input = '\r\n';
+    var expected = '\n';
+    assert.equal(normalizeNewlines(input), expected);
+  });
+
+  it('should transform CR to LF', function() {
+    var input = '\r';
+    var expected = '\n';
+    assert.equal(normalizeNewlines(input), expected);
+  });
+
+  it('should transform mixed CR+LF and LF to LF', function() {
+    var input = '\n\r\n\n\r\n\n';
+    var expected = '\n\n\n\n\n';
+    assert.equal(normalizeNewlines(input), expected);
+  });
+
+  it('should transform mixed CR+LF and CR to LF', function() {
+    var input = '\r\n\r\n\r \r\n\r';
+    var expected = '\n\n\n \n\n';
+    assert.equal(normalizeNewlines(input), expected);
+  });
+
+  it('should transform mixed CR and LF to LF', function() {
+    var input = '\n\n\r \n\r';
+    var expected = '\n\n\n \n\n';
+    assert.equal(normalizeNewlines(input), expected);
+  });
+
+  it('should transform mixed CR+LF and CR and LF to LF', function() {
+    var input = '\n\r\n\r\n\n\r \n\r\n\r';
+    var expected = '\n\n\n\n\n \n\n\n';
+    assert.equal(normalizeNewlines(input), expected);
+  });
+});


### PR DESCRIPTION
Adds a normalizeNewlines option which changes how attributes, text, comment, and CDATA nodes are compared for equality by changing all the newlines in them to the same newline character.